### PR TITLE
Switched to zprof based performance profiling task

### DIFF
--- a/tools/performance_cehck.zsh
+++ b/tools/performance_cehck.zsh
@@ -1,38 +1,40 @@
-#! /usr/bin/env zsh
+#! /usr/bin/env zsh -f
 
-function milliseconds_unix_time() {
-  echo $(($(date +%s%N) / 1000000.0))
-}
-
-function show_proc_time() {
-  local cmd=${1}
-
-  local avg_time=0
-
-  local number_of_samples=5
-
-  local start_time elapsed_time
-  for i ({1..${number_of_samples}})
-  do
-    start_time=$(milliseconds_unix_time)
-    ${cmd} 1>/dev/null 2>/dev/null
-    elapsed_time=$(($(milliseconds_unix_time) - ${start_time}))
-
-    avg_time=$((${avg_time} + ${elapsed_time}))
-  done
-
-  avg_time=$((${avg_time} / ${number_of_samples}))
-
-  printf "%40s : time (%d times avg) -> %5f ms\n" ${cmd:t} ${number_of_samples} ${avg_time}
-}
-
-# Load
+# Load commands
 for f ($(find . -iname 'git-*'))
 do
   source ${f}
 done
 
-for f ($(find . -iname 'git-*'))
+# Show how to see the result
+echo -n "\e[32m"
+cat <<EOF
+- How to see the result
+  - See the "time" row.
+  - There are 3 rows in inside of "time" row.
+  - See the 2nd row, it's "average time" of function execution, written in "ms (milliseconds)".
+
+- Note: The execution time is depends on your PC, 'git' command and the status of this repository.
+
+EOF
+echo -n "\e[0m"
+
+# Load zprof for profiling
+zmodload zsh/zprof
+
+# Configure parameters for profiling
+typeset -i number_of_samples=5
+
+# Run commands in ${number_of_samples} times for profiling
+for command_file ($(find . -iname 'git-*'))
 do
-  show_proc_time $(echo ${f} | tr -d './')
+  for i ({1..${number_of_samples}})
+  do
+    # Execute command by parsing command name from file name
+    typeset cmd=${command_file:t}
+    ${cmd} 1>/dev/null 2>/dev/null
+  done
 done
+
+# Show the result
+zprof | less


### PR DESCRIPTION
This PR changes the performance profiling task (in `tools/performance_cehck.zsh` ) by switching to `zprof` based performance profiling.